### PR TITLE
fix: use ConcurrentHashMap for per-key mock behaviour state

### DIFF
--- a/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/BehaviourService.kt
+++ b/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/BehaviourService.kt
@@ -6,12 +6,13 @@ import no.nav.soknad.arkivering.arkivmock.exceptions.*
 import no.nav.soknad.arkivering.arkivmock.service.BEHAVIOUR.*
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class BehaviourService(val objectMapper: ObjectMapper) {
 	private val logger = LoggerFactory.getLogger(javaClass)
 
-	private val behaviours: MutableMap<String, BehaviourDto> = mutableMapOf()
+	private val behaviours: MutableMap<String, BehaviourDto> = ConcurrentHashMap()
 
 	fun setNormalBehaviour(key: String) {
 		val calls = behaviours[key]?.calls ?: 0

--- a/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/FileMockService.kt
+++ b/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/FileMockService.kt
@@ -4,12 +4,13 @@ import no.nav.soknad.innsending.model.SoknadFile
 import org.springframework.stereotype.Service
 import java.io.ByteArrayOutputStream
 import java.time.OffsetDateTime
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class FileMockService {
 
 
-	private val fileBehaviours: MutableMap<String, FileResponse_Behaviour> = mutableMapOf()
+	private val fileBehaviours: MutableMap<String, FileResponse_Behaviour> = ConcurrentHashMap()
 
 	fun setFileResponse(key: String, response: String, forAttempts: Int) {
 		fileBehaviours.put(key, FileResponse_Behaviour(behaviour = FileResponses.valueOf(response), forAttempts = forAttempts))

--- a/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/SafMockService.kt
+++ b/mock/src/main/kotlin/no/nav/soknad/arkivering/arkivmock/service/SafMockService.kt
@@ -11,12 +11,13 @@ import no.nav.soknad.arkivering.saf.generated.hentjournalpostgitteksternreferans
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class SafMockService {
 	private val logger = LoggerFactory.getLogger(javaClass)
 
-	private val safBehaviours: MutableMap<String, SafResponse_Behaviour> = mutableMapOf()
+	private val safBehaviours: MutableMap<String, SafResponse_Behaviour> = ConcurrentHashMap()
 
 	fun setSafResponse(key: String, response: String, forAttempts: Int) {
 		safBehaviours.put(key, SafResponse_Behaviour(behaviour = SafResponses.valueOf(response), forAttempts = forAttempts))


### PR DESCRIPTION
Spring MVC handles each HTTP request on its own thread, so parallel requests that set or use behaviours (e.g. from parallel end-to-end tests) wrote to plain mutableMapOf() maps concurrently. Store the behaviour state in ConcurrentHashMap instead.

Part of issue navikt/archiving-infrastructure#86.